### PR TITLE
Make class dependencies easy to understand

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,5 @@
-import { Disposable, Uri, window, workspace } from "vscode";
+import { Disposable, ExtensionContext, Uri, window, workspace } from "vscode";
 import { IConfigProvider } from "./configProvider";
-import { Context } from "./extension";
 import { Logger } from "./logger";
 import { buildSATySFi } from "./runner";
 import { StatusBar } from "./statusbar";
@@ -8,16 +7,14 @@ import { showErrorWithOpenSettings } from "./util";
 
 export class Builder implements Disposable {
   private readonly disposables: Disposable[] = [];
-  private readonly configProvider: IConfigProvider;
-  private readonly logger: Logger;
-  private readonly statusBar: StatusBar;
   private abortController: AbortController | null = null;
 
-  constructor(context: Context) {
-    this.configProvider = context.configProvider;
-    this.logger = context.logger;
-    this.statusBar = context.statusBar;
-
+  constructor(
+    context: ExtensionContext,
+    private readonly configProvider: IConfigProvider,
+    private readonly logger: Logger,
+    private readonly statusBar: StatusBar,
+  ) {
     this.disposables.push(
       workspace.onDidSaveTextDocument((i) => {
         if (i.languageId !== "satysfi") return;
@@ -25,6 +22,8 @@ export class Builder implements Disposable {
         this.buildProject();
       }, this),
     );
+
+    context.subscriptions.push(this);
   }
 
   private async build(target: Uri) {

--- a/src/configProvider.ts
+++ b/src/configProvider.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { Disposable, workspace } from "vscode";
+import { Disposable, ExtensionContext, workspace } from "vscode";
 import { ZodError } from "zod";
 import { ExtensionConfig } from "./configSchema";
 import { CONFIG_SCOPE } from "./const";
@@ -18,7 +18,7 @@ export class ConfigProvider implements IConfigProvider, Disposable {
   private readonly disposables: Disposable[] = [];
   private config: ExtensionConfig | null;
 
-  constructor() {
+  constructor(context: ExtensionContext) {
     this.disposables.push(
       workspace.onDidChangeConfiguration((e) => {
         if (!e.affectsConfiguration(CONFIG_SCOPE)) return;
@@ -30,6 +30,8 @@ export class ConfigProvider implements IConfigProvider, Disposable {
     );
 
     this.config = this.parse();
+
+    context.subscriptions.push(this);
   }
 
   private parse() {

--- a/src/languageServer.ts
+++ b/src/languageServer.ts
@@ -1,8 +1,7 @@
-import { Disposable } from "vscode";
+import { Disposable, ExtensionContext } from "vscode";
 import { LanguageClient, LanguageClientOptions, ServerOptions } from "vscode-languageclient/node";
 import { IConfigProvider } from "./configProvider";
 import { ExtensionConfig } from "./configSchema";
-import { Context } from "./extension";
 import { Logger } from "./logger";
 
 export class LanguageServer implements Disposable {
@@ -10,13 +9,12 @@ export class LanguageServer implements Disposable {
   private path: string;
   private client: LanguageClient | null = null;
   private readonly disposables: Disposable[] = [];
-  private readonly configProvider: IConfigProvider;
-  private readonly logger: Logger;
 
-  constructor(context: Context) {
-    this.configProvider = context.configProvider;
-    this.logger = context.logger;
-
+  constructor(
+    context: ExtensionContext,
+    private readonly configProvider: IConfigProvider,
+    private readonly logger: Logger,
+  ) {
     const config = this.configProvider.get();
     this.enabled = config?.languageServer.enabled ?? false;
     this.path = config?.languageServer.path ?? "";
@@ -24,6 +22,8 @@ export class LanguageServer implements Disposable {
     this.configProvider.onChange((c) => this.onConfigChange(c));
 
     if (this.enabled) this.startServer();
+
+    context.subscriptions.push(this);
   }
 
   private onConfigChange(config: ExtensionConfig | null) {

--- a/src/mathHoverProvider.ts
+++ b/src/mathHoverProvider.ts
@@ -30,6 +30,7 @@ import { unescape } from "querystring";
 import {
   DiagnosticSeverity,
   Disposable,
+  ExtensionContext,
   Hover,
   HoverProvider,
   languages,
@@ -53,18 +54,20 @@ const queryStr = `
 `.trim();
 
 export class MathHoverProvider implements HoverProvider, Disposable {
-  private readonly configProvider: IConfigProvider;
-  private readonly treeSitterProvider: TreeSitterProvider;
   private readonly query: Parser.Query;
   private readonly disposables: Disposable[] = [];
   private abortController: AbortController | null = null;
 
-  constructor(configProvider: IConfigProvider, treeSitterProvider: TreeSitterProvider) {
-    this.configProvider = configProvider;
-    this.treeSitterProvider = treeSitterProvider;
+  constructor(
+    context: ExtensionContext,
+    private readonly configProvider: IConfigProvider,
+    private readonly treeSitterProvider: TreeSitterProvider,
+  ) {
     this.query = treeSitterProvider.createQuery(queryStr);
 
     this.disposables.push(languages.registerHoverProvider("satysfi", this));
+
+    context.subscriptions.push(this);
   }
 
   public async provideHover(document: TextDocument, cursor: Position): Promise<Hover | null> {

--- a/src/packageCompletion.ts
+++ b/src/packageCompletion.ts
@@ -5,21 +5,21 @@ import {
   CompletionItem,
   CompletionItemKind,
   Disposable,
+  ExtensionContext,
   languages,
   Position,
   TextDocument,
   window,
 } from "vscode";
 import { IConfigProvider } from "./configProvider";
-import { Context } from "./extension";
 
 export class PackageCompletionProvider implements Disposable {
-  private readonly configProvider: IConfigProvider;
   private readonly disposables: Disposable[] = [];
 
-  constructor(context: Context) {
-    this.configProvider = context.configProvider;
-
+  constructor(
+    context: ExtensionContext,
+    private readonly configProvider: IConfigProvider,
+  ) {
     this.disposables.push(
       languages.registerCompletionItemProvider("satysfi", {
         provideCompletionItems: (d, p) => this.providePackageCompletion(d, p),
@@ -35,6 +35,8 @@ export class PackageCompletionProvider implements Disposable {
         "@",
       ),
     );
+
+    context.subscriptions.push(this);
   }
 
   private async providePackageCompletion(document: TextDocument, position: Position) {

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -3,10 +3,10 @@ import * as vscode from "vscode";
 import { ExtensionConfig } from "../configSchema";
 import { EXTENSION_NAME } from "../const";
 
-export async function activateExtension(): Promise<void> {
-  const ext = vscode.extensions.getExtension(EXTENSION_NAME);
+export async function activateExtension(): Promise<vscode.ExtensionContext> {
+  const ext = vscode.extensions.getExtension<vscode.ExtensionContext>(EXTENSION_NAME);
   assert.ok(ext);
-  await ext.activate();
+  return await ext.activate();
 }
 
 export async function activateFile(

--- a/src/test/suite/mathHoverProvider.test.ts
+++ b/src/test/suite/mathHoverProvider.test.ts
@@ -4,7 +4,7 @@ import { Position, Range } from "vscode";
 import { MathHoverProvider } from "../../mathHoverProvider";
 import { getParser } from "../../parserProvider";
 import { TreeSitterProvider } from "../../treeSitterProvider";
-import { activateFile, defaultConfig } from "../helper";
+import { activateExtension, activateFile, defaultConfig } from "../helper";
 
 suite("test for mathHoverProvider", () => {
   test("mathHoverProvider: simple", async () => {
@@ -51,9 +51,11 @@ suite("test for mathHoverProvider", () => {
 });
 
 async function mathHoverProvider() {
+  const context = await activateExtension();
   const parser = await getParser(path.dirname(path.dirname(path.dirname(__dirname))));
-  const treeSitterProvider = new TreeSitterProvider(parser);
+  const treeSitterProvider = new TreeSitterProvider(context, parser);
   return new MathHoverProvider(
+    context,
     {
       get() {
         return { ...defaultConfig, mathPreview: { ...defaultConfig.mathPreview, when: "onHover" } };

--- a/src/treeSitterProvider.ts
+++ b/src/treeSitterProvider.ts
@@ -1,15 +1,23 @@
-import { Disposable, TextDocument, TextDocumentChangeEvent, Uri, workspace } from "vscode";
+import {
+  Disposable,
+  ExtensionContext,
+  TextDocument,
+  TextDocumentChangeEvent,
+  Uri,
+  workspace,
+} from "vscode";
 import * as Parser from "web-tree-sitter";
 import { positionToPoint } from "./util";
 
 export class TreeSitterProvider implements Disposable {
-  private readonly parser: Parser;
   private readonly language: Parser.Language;
   private readonly treeCache: Map<Uri, Parser.Tree> = new Map();
   private readonly disposables: Disposable[];
 
-  constructor(parser: Parser) {
-    this.parser = parser;
+  constructor(
+    context: ExtensionContext,
+    private readonly parser: Parser,
+  ) {
     this.language = this.parser.getLanguage();
 
     this.disposables = [
@@ -19,6 +27,8 @@ export class TreeSitterProvider implements Disposable {
     ];
 
     workspace.textDocuments.forEach(this.onOpen, this);
+
+    context.subscriptions.push(this);
   }
 
   private onOpen(document: TextDocument) {


### PR DESCRIPTION
It is undesirable to group various providers and UI elements together as a `Context` because it makes it difficult to understand the dependencies between classes. Therefore, I decided to abolish `Context` and specify each element directly in the class constructor.