### PR TITLE
Change error handling method

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,9 +1,10 @@
-import { Disposable, ExtensionContext, Uri, window, workspace } from "vscode";
+import { Disposable, ExtensionContext, TextDocument, Uri, window, workspace } from "vscode";
 import { ConfigProvider } from "./configProvider";
+import { showErrorMessage } from "./dialog";
+import { withErrorHandler } from "./error";
 import { Logger } from "./logger";
 import { buildSATySFi } from "./runner";
 import { StatusBar } from "./statusbar";
-import { showErrorWithOpenSettings } from "./util";
 
 export class Builder implements Disposable {
   private readonly disposables: Disposable[] = [];
@@ -16,19 +17,26 @@ export class Builder implements Disposable {
     private readonly statusBar: StatusBar,
   ) {
     this.disposables.push(
-      workspace.onDidSaveTextDocument((i) => {
-        if (i.languageId !== "satysfi") return;
-        if (this.configProvider.get()?.build.when !== "onSave") return;
-        this.buildProject();
-      }, this),
+      workspace.onDidSaveTextDocument(
+        withErrorHandler((d) => this.onDidSaveTextDocument(d), logger),
+      ),
     );
 
     context.subscriptions.push(this);
   }
 
+  private async onDidSaveTextDocument(document: TextDocument) {
+    if (document.languageId !== "satysfi") return;
+
+    const config = this.configProvider.get();
+
+    if (config.build.when === "onSave") {
+      await this.buildProject();
+    }
+  }
+
   private async build(target: Uri) {
     const config = this.configProvider.get();
-    if (config == null) return;
 
     this.abortController?.abort();
     this.abortController = new AbortController();
@@ -36,56 +44,34 @@ export class Builder implements Disposable {
     this.logger.clearLogBuild();
     this.statusBar.show("sync~spin", "Building...");
 
-    try {
-      // TODO: use diagnostics
-      const { success } = await buildSATySFi(
-        config.executable,
-        target,
-        config.build.buildOptions,
-        this.abortController.signal,
-        { logger: this.logger },
+    // TODO: use diagnostics
+    const { success } = await buildSATySFi(
+      config.executable,
+      target,
+      config.build.buildOptions,
+      this.abortController.signal,
+      { logger: this.logger },
+    ).finally(() => this.statusBar.hide());
+
+    this.logger.log(success ? `Build Success: ${target}` : `Build Fail: ${target}`);
+
+    if (!success) {
+      await showErrorMessage(
+        `Failed to build ${target.fsPath}`,
+        { type: "openBuildLog" },
+        this.logger,
       );
-
-      if (success) this.onBuildSuccess(target);
-      else this.onBuildFail(target);
-    } catch (e) {
-      if (e instanceof Error && e.name === "AbortError") {
-        return;
-      }
-
-      showErrorWithOpenSettings(
-        `SATySFi executable not found. Please set the executable path in the settings.`,
-        false,
-      );
-
-      this.logger.log(`Build ${e}`);
-    }
-
-    this.statusBar.hide();
-  }
-
-  private async onBuildSuccess(target: Uri) {
-    this.logger.log(`Build Success: ${target}`);
-  }
-
-  private async onBuildFail(target: Uri) {
-    this.logger.log(`Build Fail: ${target}`);
-    const item = await window.showErrorMessage(`failed to build ${target.fsPath}`, "Open Log");
-
-    if (item === "Open Log") {
-      this.logger.showBuildLog();
     }
   }
 
   public async buildProject(): Promise<void> {
     const config = this.configProvider.get();
-    if (config == null) return;
 
     const document = window.activeTextEditor?.document;
 
     if (document && document.fileName.endsWith(".saty")) {
       // build current document
-      this.build(document.uri);
+      await this.build(document.uri);
       return;
     }
 
@@ -94,9 +80,9 @@ export class Builder implements Disposable {
     if (rootFilePath) {
       const [rootFile] = await workspace.findFiles(rootFilePath, null, 1);
       if (rootFile) {
-        this.build(rootFile);
+        await this.build(rootFile);
       } else {
-        window.showErrorMessage(`Root file not found: ${rootFilePath}`);
+        await showErrorMessage(`Root file not found: ${rootFilePath}`, undefined, this.logger);
       }
       return;
     }
@@ -105,15 +91,16 @@ export class Builder implements Disposable {
     const satyFiles = await workspace.findFiles("**/*.saty", "**/.git/**", 2);
     switch (satyFiles.length) {
       case 0:
-        window.showErrorMessage("No .saty file found in workspace.");
+        await showErrorMessage("No .saty file found in workspace.", undefined, this.logger);
         break;
       case 1:
-        if (satyFiles[0]) this.build(satyFiles[0]);
+        if (satyFiles[0]) await this.build(satyFiles[0]);
         break;
       default:
-        showErrorWithOpenSettings(
+        await showErrorMessage(
           "Multiple .saty files found in workspace. Please set the root .saty file in settings.",
-          true,
+          { type: "openSettings", scope: "workspace" },
+          this.logger,
         );
         break;
     }

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -1,0 +1,63 @@
+import { commands, window } from "vscode";
+import { EXTENSION_NAME } from "./const";
+import { Logger } from "./logger";
+
+export type MessageAction =
+  | { type: "openSettings"; scope: "user" | "workspace" }
+  | { type: "openLog" }
+  | { type: "openBuildLog" };
+
+export async function showErrorMessage(
+  message: string,
+  action: MessageAction | undefined,
+  logger: Logger,
+): Promise<void> {
+  if (action) {
+    const actionItems = getActionItems(action, logger);
+    const selected = await window.showErrorMessage(
+      message,
+      ...actionItems.map(({ title }) => title),
+    );
+    if (selected) actionItems.find(({ title }) => title === selected)?.onClicked();
+  } else {
+    await window.showErrorMessage(message);
+  }
+}
+
+function getActionItems(
+  action: MessageAction,
+  logger: Logger,
+): { title: string; onClicked: () => unknown }[] {
+  switch (action.type) {
+    case "openSettings":
+      return [
+        {
+          title: "Open Settings",
+          onClicked: () => {
+            commands.executeCommand("workbench.action.openSettings", `@ext:${EXTENSION_NAME}`);
+            if (action.scope === "workspace") {
+              commands.executeCommand("workbench.action.openWorkspaceSettings");
+            }
+          },
+        },
+      ];
+    case "openLog":
+      return [
+        {
+          title: "Open Log",
+          onClicked: () => {
+            logger.showLog();
+          },
+        },
+      ];
+    case "openBuildLog":
+      return [
+        {
+          title: "Open Log",
+          onClicked: () => {
+            logger.showBuildLog();
+          },
+        },
+      ];
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,94 @@
+import { ZodError } from "zod";
+import { ExtensionConfig } from "./configSchema";
+import { MessageAction, showErrorMessage } from "./dialog";
+import { Logger } from "./logger";
+
+export type ExtensionErrorPayload = {
+  dialog?: {
+    message: string;
+    action?: MessageAction;
+  };
+  log?: string;
+};
+
+export function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
+  return typeof e === "object" && e != null && "code" in e;
+}
+
+export class ExtensionError extends Error {
+  constructor(
+    public readonly payload: ExtensionErrorPayload,
+    options?: ErrorOptions,
+  ) {
+    super(payload.dialog?.message, options);
+  }
+}
+
+export class ConfigError extends ExtensionError {
+  constructor(cause: ZodError<ExtensionConfig>) {
+    super(
+      {
+        dialog: {
+          message: `Setting has an invalid type: ${formatZodError(cause)}`,
+          action: { type: "openSettings", scope: "user" },
+        },
+      },
+      { cause },
+    );
+  }
+}
+
+export class CommandNotFoundError extends ExtensionError {
+  constructor(command: string, options?: ErrorOptions) {
+    super(
+      {
+        dialog: {
+          message: `Command "${command}" not found. Install it or configure it in the settings.`,
+          action: { type: "openSettings", scope: "user" },
+        },
+      },
+      options,
+    );
+  }
+}
+
+export function withErrorHandler<T extends Array<unknown>, R>(
+  fn: (...args: T) => Promise<R>,
+  logger: Logger,
+  thisArgs?: unknown,
+): (...args: T) => Promise<R | null> {
+  const bindedFn = thisArgs ? fn.bind(thisArgs) : fn;
+  return async (...args: T): Promise<R | null> => {
+    try {
+      return await bindedFn(...args);
+    } catch (e: unknown) {
+      await handleError(e, logger);
+      return null;
+    }
+  };
+}
+
+export async function handleError(e: unknown, logger: Logger): Promise<void> {
+  if (!(e instanceof Error)) return;
+
+  const { dialog, log } = createMessage(e);
+  if (log) logger.log(log);
+  if (dialog) await showErrorMessage(dialog.message, dialog.action, logger);
+}
+
+function createMessage(e: Error): ExtensionErrorPayload {
+  if (e.name === "AbortError") return {};
+  if (e instanceof ExtensionError) return e.payload;
+
+  return {
+    dialog: {
+      message: "Unknown error occurred.",
+      action: { type: "openLog" },
+    },
+    log: `${e.name}: ${e.message}`,
+  };
+}
+
+function formatZodError(error: ZodError<ExtensionConfig>) {
+  return error.issues.map((issue) => `${issue.path.join(".")}`).join(", ");
+}

--- a/src/languageServer.ts
+++ b/src/languageServer.ts
@@ -15,7 +15,7 @@ export class LanguageServer implements Disposable {
     private readonly configProvider: ConfigProvider,
     private readonly logger: Logger,
   ) {
-    const config = this.configProvider.get();
+    const config = this.configProvider.safeGet();
     this.enabled = config?.languageServer.enabled ?? false;
     this.path = config?.languageServer.path ?? "";
 

--- a/src/packageCompletion.ts
+++ b/src/packageCompletion.ts
@@ -109,7 +109,7 @@ export class PackageCompletionProvider implements Disposable {
   }
 
   private getConfig() {
-    return this.configProvider.get()?.packageCompletion;
+    return this.configProvider.safeGet()?.packageCompletion;
   }
 
   public dispose() {

--- a/src/test/suite/mathHoverProvider.test.ts
+++ b/src/test/suite/mathHoverProvider.test.ts
@@ -3,6 +3,7 @@ import path from "path";
 import sinon from "sinon";
 import { Position, Range } from "vscode";
 import { ConfigProvider } from "../../configProvider";
+import { ExtensionConfig } from "../../configSchema";
 import { MathHoverProvider } from "../../mathHoverProvider";
 import { getParser } from "../../parserProvider";
 import { TreeSitterProvider } from "../../treeSitterProvider";
@@ -55,11 +56,13 @@ suite("test for mathHoverProvider", () => {
 async function mathHoverProvider() {
   const context = await activateExtension();
 
-  const configProvider = sinon.createStubInstance(ConfigProvider);
-  configProvider.get.returns({
+  const config: ExtensionConfig = {
     ...defaultConfig,
     mathPreview: { ...defaultConfig.mathPreview, when: "onHover" },
-  });
+  };
+  const configProvider = sinon.createStubInstance(ConfigProvider);
+  configProvider.get.returns(config);
+  configProvider.safeGet.returns(config);
 
   const parser = await getParser(path.dirname(path.dirname(path.dirname(__dirname))));
   const treeSitterProvider = new TreeSitterProvider(context, parser);

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,21 +2,9 @@ import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { tmpdir } from "os";
 import * as path from "path";
-import { ColorThemeKind, commands, Position, window } from "vscode";
+import { ColorThemeKind, Position, window } from "vscode";
 import * as Parser from "web-tree-sitter";
 import { EXTENSION_NAME } from "./const";
-
-export async function showErrorWithOpenSettings(
-  message: string,
-  workspace: boolean,
-): Promise<void> {
-  const item = await window.showErrorMessage(message, "Open Settings");
-
-  if (item === "Open Settings") {
-    commands.executeCommand("workbench.action.openSettings", `@ext:${EXTENSION_NAME}`);
-    if (workspace) commands.executeCommand("workbench.action.openWorkspaceSettings");
-  }
-}
 
 export function getWorkPath(originalPath: string): string {
   const ext = path.extname(originalPath);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": ["es6"],
+    "lib": ["es2022"],
     "sourceMap": true,
     "rootDir": "src",
     "esModuleInterop": true,


### PR DESCRIPTION
In the original code, error handling was scattered throughout the program and was difficult to maintain. In this PR, custom errors and functions for handling them are defined in `error.ts` and used throughout the program.

Added
- `error.ts` : Define some `ExtensionError`s and their handler (`withErrorHandler`).
- `dialog.ts` : Define `showErrorMessage` to show dialog.

Modified
- `configProvider.ts` : `ConfigProvider.prototype.get` returns `ExtensionConfig` or throws `ConfigError`. You can use `safeGet` to get the config without exception.
- `runner.ts` : `spawn` might throw `CommandNotFoundError`.
- `tsconfig.json` : Specify `es2022` for `lib` option to support `ErrorOptions` in `ExtensionError`

Other changes are subordinate to the above.