### PR TITLE
ESLint: Stricter config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,11 +5,27 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   { languageOptions: { globals: globals.node } },
-  { ignores: [".vscode-test/", "dist/", "out/", "tools/", "**/*.d.ts"] },
-  eslint.configs.recommended,
-  ...tseslint.configs.strict,
-  ...tseslint.configs.stylistic,
   {
+    ignores: [
+      ".vscode-test/",
+      "dist/",
+      "out/",
+      "tools/",
+      "src/test/",
+      "esbuild.mjs",
+      "eslint.config.mjs",
+      "**/*.d.ts",
+    ],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: true,
+      },
+    },
     rules: {
       "@typescript-eslint/no-unused-vars": [
         "warn",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,8 @@ export default tseslint.config(
   { languageOptions: { globals: globals.node } },
   { ignores: [".vscode-test/", "dist/", "out/", "tools/", "**/*.d.ts"] },
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.strict,
+  ...tseslint.configs.stylistic,
   {
     rules: {
       "@typescript-eslint/no-unused-vars": [

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -51,9 +51,11 @@ export class Builder implements Disposable {
       config.build.buildOptions,
       this.abortController.signal,
       { logger: this.logger },
-    ).finally(() => this.statusBar.hide());
+    ).finally(() => {
+      this.statusBar.hide();
+    });
 
-    this.logger.log(success ? `Build Success: ${target}` : `Build Fail: ${target}`);
+    this.logger.log(success ? `Build Success: ${target.fsPath}` : `Build Fail: ${target.fsPath}`);
 
     if (!success) {
       await showErrorMessage(
@@ -69,7 +71,7 @@ export class Builder implements Disposable {
 
     const document = window.activeTextEditor?.document;
 
-    if (document && document.fileName.endsWith(".saty")) {
+    if (document?.fileName.endsWith(".saty")) {
       // build current document
       await this.build(document.uri);
       return;
@@ -107,7 +109,9 @@ export class Builder implements Disposable {
   }
 
   public dispose(): void {
-    this.disposables.forEach((d) => d.dispose());
+    this.disposables.forEach((d) => {
+      d.dispose();
+    });
     this.abortController?.abort();
   }
 }

--- a/src/configProvider.ts
+++ b/src/configProvider.ts
@@ -67,6 +67,8 @@ export class ConfigProvider implements Disposable {
   }
 
   public dispose() {
-    this.disposables.forEach((d) => d.dispose());
+    this.disposables.forEach((d) => {
+      d.dispose();
+    });
   }
 }

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -33,10 +33,13 @@ function getActionItems(
       return [
         {
           title: "Open Settings",
-          onClicked: () => {
-            commands.executeCommand("workbench.action.openSettings", `@ext:${EXTENSION_NAME}`);
+          onClicked: async () => {
+            await commands.executeCommand(
+              "workbench.action.openSettings",
+              `@ext:${EXTENSION_NAME}`,
+            );
             if (action.scope === "workspace") {
-              commands.executeCommand("workbench.action.openWorkspaceSettings");
+              await commands.executeCommand("workbench.action.openWorkspaceSettings");
             }
           },
         },

--- a/src/error.ts
+++ b/src/error.ts
@@ -3,13 +3,13 @@ import { ExtensionConfig } from "./configSchema";
 import { MessageAction, showErrorMessage } from "./dialog";
 import { Logger } from "./logger";
 
-export type ExtensionErrorPayload = {
+export interface ExtensionErrorPayload {
   dialog?: {
     message: string;
     action?: MessageAction;
   };
   log?: string;
-};
+}
 
 export function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
   return typeof e === "object" && e != null && "code" in e;
@@ -52,7 +52,7 @@ export class CommandNotFoundError extends ExtensionError {
   }
 }
 
-export function withErrorHandler<T extends Array<unknown>, R>(
+export function withErrorHandler<T extends unknown[], R>(
   fn: (...args: T) => Promise<R>,
   logger: Logger,
   thisArgs?: unknown,

--- a/src/error.ts
+++ b/src/error.ts
@@ -90,5 +90,5 @@ function createMessage(e: Error): ExtensionErrorPayload {
 }
 
 function formatZodError(error: ZodError<ExtensionConfig>) {
-  return error.issues.map((issue) => `${issue.path.join(".")}`).join(", ");
+  return error.issues.map((issue) => issue.path.join(".")).join(", ");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,9 @@ export async function activate(context: ExtensionContext): Promise<ExtensionCont
     COMMAND_TYPECHECK,
     withErrorHandler(() => typeChecker.checkCurrentDocument(), logger),
   );
-  commands.registerCommand(COMMAND_OPEN_BUILD_LOG, () => logger.showBuildLog());
+  commands.registerCommand(COMMAND_OPEN_BUILD_LOG, () => {
+    logger.showBuildLog();
+  });
   commands.registerCommand(COMMAND_RESTART_LANGUAGE_SERVER, () => languageServer.restartServer());
 
   // returns the extension context for testing

--- a/src/logParser.ts
+++ b/src/logParser.ts
@@ -21,8 +21,8 @@ export function parseLog(
 ): Map<string, Diagnostic[]> {
   let target: string | undefined;
   // filename -> fullpath
-  const filenameMap: Map<string, string> = new Map();
-  const diagnostics: Map<string, Diagnostic[]> = new Map();
+  const filenameMap = new Map<string, string>();
+  const diagnostics = new Map<string, Diagnostic[]>();
 
   for (const { groups } of output.matchAll(regexAll)) {
     if (groups == null) throw new Error(`Internal Error: match failed`);
@@ -65,7 +65,7 @@ export function parseLog(
   return diagnostics;
 }
 
-function parseRange(groups: { [key: string]: string }) {
+function parseRange(groups: Record<string, string>) {
   const startLine = Number(groups["startLineMulti"] ?? groups["lineSingle"]);
   const endLine = Number(groups["endLineMulti"] ?? groups["lineSingle"]);
   const startCol = Number(groups["startColMulti"] ?? groups["startColSingle"]);

--- a/src/logParser.ts
+++ b/src/logParser.ts
@@ -81,7 +81,7 @@ function parseBody(
   message = message.replace(/^\s{4}/gm, "").trim();
 
   const match = message.match(regexConstraint);
-  if (!match || !match.groups || !match.groups["filename"]) {
+  if (!match?.groups?.["filename"]) {
     return { message, relatedInformation: [] };
   }
 

--- a/src/packageCompletion.ts
+++ b/src/packageCompletion.ts
@@ -52,7 +52,7 @@ export class PackageCompletionProvider implements Disposable {
     return [];
   }
 
-  private async provideRequireImportCompletion(_: TextDocument, position: Position) {
+  private provideRequireImportCompletion(_: TextDocument, position: Position) {
     if (position.character !== 1) return undefined;
 
     return ["require", "import"].map((label) => {
@@ -67,7 +67,7 @@ export class PackageCompletionProvider implements Disposable {
 
   private listPackageCompletions(dir: string) {
     const defaultSearchRoot = path.join(homedir(), ".satysfi", "dist", "packages");
-    const searchRoot = this.getConfig()?.searchPath || defaultSearchRoot;
+    const searchRoot = (this.getConfig()?.searchPath ?? "") || defaultSearchRoot;
     const searchPath = path.join(searchRoot, dir);
 
     return this.listCompletions(searchPath);
@@ -95,7 +95,7 @@ export class PackageCompletionProvider implements Disposable {
           item.command = { command: "editor.action.triggerSuggest", title: "package" };
         } else {
           const match = d.name.match(/^(.+)\.saty[hg]$/);
-          if (!match || !match[1]) return [];
+          if (!match?.[1]) return [];
           item = new CompletionItem(match[1], CompletionItemKind.File);
         }
 
@@ -113,6 +113,8 @@ export class PackageCompletionProvider implements Disposable {
   }
 
   public dispose() {
-    this.disposables.forEach((d) => d.dispose());
+    this.disposables.forEach((d) => {
+      d.dispose();
+    });
   }
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -33,9 +33,8 @@ export async function buildSATySFi(
     logger: options?.logger,
   }).finally(() => {
     if (options?.content) {
-      fs.unlink(workPath);
       // Failure to delete is not a problem because aux files are not always generated.
-      fs.unlink(getAuxPath(workPath)).catch(() => undefined);
+      void Promise.allSettled([fs.unlink(workPath), fs.unlink(getAuxPath(workPath))]);
     }
   });
 
@@ -55,12 +54,12 @@ export function spawn(
     let stdout = "";
     let stderr = "";
 
-    spawned.stdout.on("data", (data) => {
+    spawned.stdout.on("data", (data: Buffer) => {
       stdout += data.toString();
       if (options?.logger) options.logger.logBuild(data.toString());
     });
 
-    spawned.stderr.on("data", (data) => {
+    spawned.stderr.on("data", (data: Buffer) => {
       stderr += data.toString();
       if (options?.logger) options.logger.logBuild(data.toString());
     });

--- a/src/treeSitterProvider.ts
+++ b/src/treeSitterProvider.ts
@@ -21,12 +21,20 @@ export class TreeSitterProvider implements Disposable {
     this.language = this.parser.getLanguage();
 
     this.disposables = [
-      workspace.onDidOpenTextDocument(this.onOpen, this),
-      workspace.onDidCloseTextDocument(this.onClose, this),
-      workspace.onDidChangeTextDocument(this.onChange, this),
+      workspace.onDidOpenTextDocument((e) => {
+        this.onOpen(e);
+      }),
+      workspace.onDidCloseTextDocument((e) => {
+        this.onClose(e);
+      }),
+      workspace.onDidChangeTextDocument((e) => {
+        this.onChange(e);
+      }),
     ];
 
-    workspace.textDocuments.forEach(this.onOpen, this);
+    workspace.textDocuments.forEach((e) => {
+      this.onOpen(e);
+    });
 
     context.subscriptions.push(this);
   }
@@ -89,6 +97,8 @@ export class TreeSitterProvider implements Disposable {
   }
 
   public dispose(): void {
-    this.disposables.forEach((i) => i.dispose());
+    this.disposables.forEach((i) => {
+      i.dispose();
+    });
   }
 }

--- a/src/treeSitterProvider.ts
+++ b/src/treeSitterProvider.ts
@@ -11,7 +11,7 @@ import { positionToPoint } from "./util";
 
 export class TreeSitterProvider implements Disposable {
   private readonly language: Parser.Language;
-  private readonly treeCache: Map<Uri, Parser.Tree> = new Map();
+  private readonly treeCache = new Map<Uri, Parser.Tree>();
   private readonly disposables: Disposable[];
 
   constructor(

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -9,7 +9,7 @@ import {
   workspace,
 } from "vscode";
 import { ConfigProvider } from "./configProvider";
-import { withErrorHandler } from "./error";
+import { handleError, withErrorHandler } from "./error";
 import { Logger } from "./logger";
 import { buildSATySFi } from "./runner";
 
@@ -43,7 +43,9 @@ export class TypeChecker implements Disposable {
     );
 
     if (this.getConfig()?.when === "onSave" || this.getConfig()?.when === "onFileChange") {
-      workspace.textDocuments.forEach((i) => this.checkDocument(i), this);
+      Promise.all(workspace.textDocuments.map((i) => this.checkDocument(i))).catch((e: unknown) =>
+        handleError(e, this.logger),
+      );
     }
 
     context.subscriptions.push(this);
@@ -82,7 +84,9 @@ export class TypeChecker implements Disposable {
   public dispose(): void {
     this.collection.clear();
     this.collection.dispose();
-    this.disposables.forEach((i) => i.dispose());
+    this.disposables.forEach((i) => {
+      i.dispose();
+    });
     this.abortController?.abort();
   }
 }


### PR DESCRIPTION
Enable [`strict-type-checked`](https://typescript-eslint.io/users/configs#strict-type-checked) and [`stylistic-type-checked`](https://typescript-eslint.io/users/configs#stylistic-type-checked) to find bugs and bad practices. The behavior of the program is basically unchanged, but the notation of file paths in the post-build logs changes a bit.