### PR TITLE
Update artifact action versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build tree-sitter parsers
         run: npm run build:tree-sitter
       - name: Upload parsers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: parsers
           path: parsers
@@ -44,7 +44,7 @@ jobs:
       - name: Run npm ci without node-gyp rebuild
         run: npm ci --ignore-scripts
       - name: Download parsers
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: parsers
           path: parsers


### PR DESCRIPTION
Update artifact actions ([actions/upload-artifact](https://github.com/actions/upload-artifact), [actions/download-artifact](https://github.com/actions/download-artifact)) to v4 since v3 is now deprecated.

ref: [Deprecation notice: v3 of the artifact actions - GitHub Changelog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)