### PR TITLE
Update node to v22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 22.x
       - name: Run npm ci
         run: npm ci
       - name: Build tree-sitter parsers
@@ -34,13 +34,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Force git to use https instead of ssh
         run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 22.x
       - name: Run npm ci without node-gyp rebuild
         run: npm ci --ignore-scripts
       - name: Download parsers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 22.x
       - name: Install dependencies
         run: npm ci
       - name: Build tree-sitter parsers

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "mocha": "^11.7.5",
         "prettier": "^3.8.1",
         "tree-sitter-cli": "^0.21.0",
-        "tree-sitter-satysfi": "github:monaqa/tree-sitter-satysfi",
+        "tree-sitter-satysfi": "github:pickoba/tree-sitter-satysfi#satysfi-workshop",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -2979,7 +2979,7 @@
     },
     "node_modules/tree-sitter-satysfi": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/monaqa/tree-sitter-satysfi.git#5519c547418ecb31ac7d63e64653aed726b5d1c3",
+      "resolved": "git+ssh://git@github.com/pickoba/tree-sitter-satysfi.git#adf319c8c4f5c7820ad83deea6510b4b5c47e030",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
-        "@types/node": "^18.19.130",
+        "@types/node": "^22.16.0",
         "@types/vscode": "1.86",
         "@typescript-eslint/eslint-plugin": "^8.57.1",
         "@typescript-eslint/parser": "^8.57.1",
@@ -30,6 +30,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
+        "node": ">=22 <23",
         "vscode": "^1.86.0"
       }
     },
@@ -695,12 +696,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -3035,10 +3037,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "mocha": "^11.7.5",
     "prettier": "^3.8.1",
     "tree-sitter-cli": "^0.21.0",
-    "tree-sitter-satysfi": "github:monaqa/tree-sitter-satysfi",
+    "tree-sitter-satysfi": "github:pickoba/tree-sitter-satysfi#satysfi-workshop",
     "typescript": "^5.9.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "theme": "dark"
   },
   "engines": {
+    "node": ">=22 <23",
     "vscode": "^1.86.0"
   },
   "categories": [
@@ -236,7 +237,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "@types/node": "^18.19.130",
+    "@types/node": "^22.16.0",
     "@types/vscode": "1.86",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",


### PR DESCRIPTION
Update Node.js version to v22. We are also updating the CI settings at the same time.

Since the original tree-sitter-satysfi was not fully compatible with Node v22, I have updated it to a forked version.